### PR TITLE
Fix docker build trailing space error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: Dockerfile
       args:
         - NEXT_PUBLIC_EXTERNAL_API_URL=${NEXT_PUBLIC_EXTERNAL_API_URL}
-        - EXTERNAL_API_URL = ${EXTERNAL_API_URL}
+        - EXTERNAL_API_URL=${EXTERNAL_API_URL}
         - NEXTAUTH_SECRET=${NEXTAUTH_SECRET}
         - NEXTAUTH_URL=${NEXTAUTH_URL}
         - API_BASE_URL=${API_BASE_URL}


### PR DESCRIPTION
Remove trailing space from `EXTERNAL_API_URL` in `docker-compose.yml` to fix a `docker compose` decoding error.

---
<a href="https://cursor.com/background-agent?bcId=bc-ecffda0e-2af2-4d7e-8702-66f107c57306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ecffda0e-2af2-4d7e-8702-66f107c57306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

