### PR TITLE
Enhance rfq

### DIFF
--- a/components/prequalification/application-form.tsx
+++ b/components/prequalification/application-form.tsx
@@ -288,7 +288,7 @@ export default function ApplicationForm({ children, open = false, onOpenChange, 
                     status: (statusCode || "O") as string,
                     deadline,
                     applicantCount: r.applicantCount,
-                    hasApplied: Boolean((r as { hasApplied?: boolean }).hasApplied) || Boolean((r as { applicationId?: unknown }).applicationId),
+                    hasApplied: Boolean((r as any).hasApplied || (r as any).appliedCount > 0 || (r as any).applicationId),
                     applicationId: (r as { applicationId?: unknown }).applicationId ? String((r as { applicationId?: unknown }).applicationId) : undefined,
                 };
             }).filter(r => r.id);
@@ -538,7 +538,7 @@ export default function ApplicationForm({ children, open = false, onOpenChange, 
                                     </div>
                                 )}
                             </div>
-                            {selectedRoundId && (!rounds[0]?.hasApplied) && (
+                            {selectedRoundId && (
                                 <div className="space-y-4 pt-6 transition-all duration-300 ease-in-out animate-in slide-in-from-bottom-4">
                                     <div className="flex items-center justify-between">
                                         <Label htmlFor="categories" id="categories-label" className="text-base font-semibold flex items-center gap-2">
@@ -550,7 +550,11 @@ export default function ApplicationForm({ children, open = false, onOpenChange, 
                                     {categoriesLoadingState === "loading" && <LoadingSkeleton />}
                                     {categoriesLoadingState === "error" && <ErrorState error={categoryError} onRetry={fetchCategories} />}
                                     {categoriesLoadingState === "success" && categories.length > 0 && (
-                                        <CategorySelector categories={categories} selectedIds={selectedCategoryIds} onToggle={handleToggleCategory} error={form.formState.errors.categoryIds?.message} />
+                                        rounds[0]?.hasApplied ? (
+                                            <WarningState message="You have already applied to this round. Categories are locked." />
+                                        ) : (
+                                            <CategorySelector categories={categories} selectedIds={selectedCategoryIds} onToggle={handleToggleCategory} error={form.formState.errors.categoryIds?.message} />
+                                        )
                                     )}
                                     {categoriesLoadingState === "success" && categories.length === 0 && (
                                         <div className="flex flex-col items-center justify-center py-8 text-center border-2 border-dashed border-gray-200 rounded-lg bg-gray-50/50 dark:border-gray-800 dark:bg-gray-900/10">

--- a/components/prequalification/rounds-table.tsx
+++ b/components/prequalification/rounds-table.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useMemo, useState } from "react"
+import { useRouter } from "next/navigation"
 import { format } from "date-fns"
 import { ChevronLeft, ChevronRight, FilePlus2, Lock } from "lucide-react"
 import { Button } from "@/components/common/button"
@@ -52,6 +53,7 @@ export default function RoundsTable({
 }) {
     const { data: session } = useSession()
     const accessToken = session?.accessToken as string | undefined
+    const router = useRouter()
     const [openRoundId, setOpenRoundId] = useState<string | null>(null)
     const [appliedRoundIds, setAppliedRoundIds] = useState<Set<string>>(new Set())
     // Removed submittingRoundId because we now always open the full application form (categories required)
@@ -273,8 +275,14 @@ export default function RoundsTable({
                 defaultRoundId={openRoundId || undefined}
                 onOpenChange={(o) => { if (!o) setOpenRoundId(null) }}
                 onSuccess={({ roundId, applicationId }) => {
-                    setAppliedRoundIds(prev => new Set(prev).add(roundId))
+                    setAppliedRoundIds(prev => {
+                        const next = new Set(prev)
+                        next.add(roundId)
+                        return next
+                    })
                     toast.success('Application submitted', { description: applicationId ? `Reference: ${applicationId}` : undefined })
+                    // Refresh server-rendered rounds to update applied counts and categories
+                    try { router.refresh() } catch {}
                     setOpenRoundId(null)
                 }}
             >


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the prequalification application and rounds table components, primarily focused on more robust handling of application eligibility, category selection, and UI feedback. The changes ensure that application logic correctly respects backend flags, date ranges, and overlapping rounds, while also providing clearer feedback to users about their application status.

Eligibility and application logic improvements:
* Added frontend guardrails to disallow applications to rounds that haven't started or overlap with other rounds, unless explicitly allowed by the backend; this uses new helper functions `toTime` and `rangesOverlap` for date calculations. [[1]](diffhunk://#diff-7d270b55c3c4bc1d7e5daa69a9fa0295e409c38e3ee5295be30e650c66097c0eR21-R36) [[2]](diffhunk://#diff-7d270b55c3c4bc1d7e5daa69a9fa0295e409c38e3ee5295be30e650c66097c0eL85-R125)
* Refactored the eligibility logic to prioritize backend-provided `canApply` flags and fallback to frontend checks, ensuring consistent handling of application permissions. [[1]](diffhunk://#diff-7d270b55c3c4bc1d7e5daa69a9fa0295e409c38e3ee5295be30e650c66097c0eL85-R125) [[2]](diffhunk://#diff-7d270b55c3c4bc1d7e5daa69a9fa0295e409c38e3ee5295be30e650c66097c0eL98-R136) [[3]](diffhunk://#diff-7d270b55c3c4bc1d7e5daa69a9fa0295e409c38e3ee5295be30e650c66097c0eL119-R157)

Category selection and feedback:
* Updated the category selection UI to show a warning and lock categories when the user has already applied to a round, preventing further changes.
* Simplified the logic for determining if a user has applied to a round, now considering `hasApplied`, `appliedCount`, or `applicationId` for more accurate status.

UI and state management enhancements:
* Added a call to `router.refresh()` after successful application submission to ensure the rounds table reflects the latest application counts and eligibility.
* Removed unnecessary conditionals in rendering the application form, always showing the form when a round is selected.