### PR TITLE
Adjust the display of the applied categories

### DIFF
--- a/components/prequalification/category-applications.tsx
+++ b/components/prequalification/category-applications.tsx
@@ -176,8 +176,10 @@ export default function CategoryApplications({ round, className }: CategoryAppli
         );
     }
 
-    const appliedCategories = round.categories.filter(cat => cat.has_applied);
-    const totalCategories = round.categories.length;
+    // Deduplicate categories by id to avoid duplicates in UI
+    const uniqueCategories = Array.from(new Map(round.categories.map(c => [c.category_id, c])).values());
+    const appliedCategories = uniqueCategories.filter(cat => cat.has_applied);
+    const totalCategories = uniqueCategories.length;
     
     if (appliedCategories.length === 0) {
         return (
@@ -250,7 +252,7 @@ export default function CategoryApplications({ round, className }: CategoryAppli
                         </div>
                     )}
                     
-                    <CategoryDetailView categories={round.categories} />
+                    <CategoryDetailView categories={uniqueCategories} />
                 </div>
             </DialogContent>
         </Dialog>

--- a/components/prequalification/rounds-table.tsx
+++ b/components/prequalification/rounds-table.tsx
@@ -95,33 +95,50 @@ export default function RoundsTable({
                     const appliedCategories = r.categories?.filter(cat => cat.has_applied) || [];
                     const hasAnyApplication = appliedCategories.length > 0 || appliedRoundIds.has(r.id);
                     const createdByOwner = (r as any).createdByOwner === true || (r as any).createdByOwner === 1;
-                    
+
+                    // New backend-aligned flags
+                    const supplierEligible = (r as any).supplierEligible === false ? false : ((r as any).supplierEligible ?? true);
+                    const isFutureWindow = Boolean((r as any).isFutureWindow);
+                    const duplicateWithinRange = Boolean((r as any).duplicateWithinRange);
+                    const primaryWindowRoundTitle = (r as any).primaryWindowRoundTitle as string | undefined;
+
                     // Check if there are any categories available to apply to
                     const availableCategories = r.categories?.filter(cat => !cat.has_applied) || [];
                     const canApplyToMore = availableCategories.length > 0;
-                    
-                    // Prefer backend decision if provided
+
+                    // Prefer backend decision if provided (now authoritative)
                     const backendCanApply = (r as any).canApply !== undefined ? Boolean((r as any).canApply) : undefined;
+                    const effectiveCanApply = backendCanApply !== undefined ? backendCanApply : true;
 
-                    // Additional frontend guardrails based on dates and overlaps (requested logic)
-                    const now = Date.now();
-                    const startMs = toTime(r.startDate) ?? 0;
-                    const endMs = toTime(r.endDate) ?? 0;
-                    const windowOpen = startMs <= now && now <= endMs;
+                    // Supplier-based lock: Not Eligible
+                    if (!supplierEligible) {
+                        return (
+                            <span className="inline-flex items-center px-2 py-1 text-xs font-medium rounded-full bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400" title={'Supplier profile not approved or not a supplier'}>
+                                <Lock className="h-3 w-3 mr-1" />
+                                Not Eligible
+                            </span>
+                        )
+                    }
 
-                    // Disallow if start date not yet reached
-                    const blockedByNotStarted = startMs > now;
+                    // Not Applicable cases: future window, duplicate window, owner-created
+                    if (isFutureWindow || duplicateWithinRange || createdByOwner || !effectiveCanApply) {
+                        return (
+                            <div className="flex flex-col items-end gap-1">
+                                <span className="inline-flex items-center px-2 py-1 text-xs font-medium rounded-full bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400" title={
+                                    isFutureWindow ? 'Round not started yet' : duplicateWithinRange ? 'Another round covers this window' : createdByOwner ? 'Owner created round' : 'Not applicable'
+                                }>
+                                    <Lock className="h-3 w-3 mr-1" />
+                                    Not Applicable
+                                </span>
+                                {duplicateWithinRange && primaryWindowRoundTitle ? (
+                                    <span className="inline-flex items-center px-2 py-0.5 text-[10px] font-medium rounded bg-blue-50 text-blue-700 border border-blue-200 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-800" title={`Use this round: ${primaryWindowRoundTitle}`}>
+                                        Use this Round Name: {primaryWindowRoundTitle}
+                                    </span>
+                                ) : null}
+                            </div>
+                        )
+                    }
 
-                    // Disallow if there is another round overlapping the same date range
-                    // and backend didn't explicitly allow this round
-                    const hasOverlappingSibling = rounds.some(other => other.id !== r.id && rangesOverlap(r.startDate, r.endDate, other.startDate, other.endDate));
-                    const blockedByOverlap = hasOverlappingSibling && !hasAnyApplication;
-
-                    // Effective flag: default allow, except when not started or overlap; if backend provided canApply, honor it
-                    const effectiveCanApply = backendCanApply !== undefined
-                        ? backendCanApply
-                        : (!blockedByNotStarted && !blockedByOverlap && windowOpen);
-                    
                     if (effectiveCanApply && hasAnyApplication && !canApplyToMore) {
                         return (
                             <span
@@ -154,14 +171,7 @@ export default function RoundsTable({
                         )
                     }
                     
-                    if (!effectiveCanApply || createdByOwner) {
-                        return (
-                            <span className="inline-flex items-center px-2 py-1 text-xs font-medium rounded-full bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400" title={createdByOwner ? 'Owner created round' : 'Not eligible to apply'}>
-                                <Lock className="h-3 w-3 mr-1" />
-                                Not Eligible
-                            </span>
-                        )
-                    }
+                    // Otherwise allow new application
                     return (
                         <Button
                             type="button"

--- a/components/prequalification/rounds-view.tsx
+++ b/components/prequalification/rounds-view.tsx
@@ -234,6 +234,11 @@ export default async function RoundsView({
             startDate,
             endDate,
             maxVendors,
+            supplierEligible: (r as any).supplierEligible ?? undefined,
+            isFutureWindow: (r as any).isFutureWindow ?? undefined,
+            duplicateWithinRange: (r as any).duplicateWithinRange ?? undefined,
+            primaryWindowRoundId: (r as any).primaryWindowRoundId ?? undefined,
+            primaryWindowRoundTitle: (r as any).primaryWindowRoundTitle ?? undefined,
             categories,
             applicationSummary: categories.length > 0 ? {
                 total_categories: categories.length,

--- a/types/types.ts
+++ b/types/types.ts
@@ -5,6 +5,12 @@ export type Round = {
     startDate: string
     endDate: string
     maxVendors: number | string
+    // Backend-derived flags for action logic
+    supplierEligible?: boolean
+    isFutureWindow?: boolean
+    duplicateWithinRange?: boolean
+    primaryWindowRoundId?: number | null
+    primaryWindowRoundTitle?: string | null
     // Category-based application tracking
     categories?: RoundCategory[];
     // Summary of applications across categories


### PR DESCRIPTION
This pull request updates the prequalification application logic to align more closely with backend-driven decision flags and improves category deduplication in the UI. The most important changes include shifting eligibility and application logic to use backend-provided flags, updating UI components to reflect these changes, and ensuring categories are deduplicated before display.

**Backend-driven eligibility and application logic:**

* Added new backend-derived flags (`supplierEligible`, `isFutureWindow`, `duplicateWithinRange`, `primaryWindowRoundId`, `primaryWindowRoundTitle`) to the `Round` type in `types/types.ts`, and ensured these are passed through from backend data in `rounds-view.tsx`. [[1]](diffhunk://#diff-63111e853710c11c9f99c2f811d00e5f8a914c855524747966aea7318bc89b67R8-R13) [[2]](diffhunk://#diff-cd830d944e785e607aabd7e60109b2b65460bb53c1f02c6ec58c7642b62eeac8R237-R241)
* Updated application eligibility logic in `rounds-table.tsx` to use these backend flags as authoritative, replacing previous frontend-only checks. The UI now displays "Not Eligible" or "Not Applicable" badges based on these flags, and disables application actions accordingly. [[1]](diffhunk://#diff-7d270b55c3c4bc1d7e5daa69a9fa0295e409c38e3ee5295be30e650c66097c0eR99-R140) [[2]](diffhunk://#diff-7d270b55c3c4bc1d7e5daa69a9fa0295e409c38e3ee5295be30e650c66097c0eL157-R174)

**Category deduplication improvements:**

* Deduplicated categories by `category_id` in `category-applications.tsx` to avoid duplicate entries in the UI, and updated all relevant references to use the deduplicated list. [[1]](diffhunk://#diff-eaa0ccd3be65f0319af7591295f028f467560a4478b5e8a1bd2a7094978db583L179-R182) [[2]](diffhunk://#diff-eaa0ccd3be65f0319af7591295f028f467560a4478b5e8a1bd2a7094978db583L253-R255)