### PR TITLE
Fix the display of tenders

### DIFF
--- a/app/api/tender-invitations/route.ts
+++ b/app/api/tender-invitations/route.ts
@@ -85,29 +85,22 @@ export async function GET(request: NextRequest) {
     if (externalApiUrl) {
       try {
         const apiUrl = `${externalApiUrl}/api/tender-invitations?${queryParams}`;
-        
         const response = await fetch(apiUrl, {
           headers: {
             'Authorization': `Bearer ${session.accessToken}`,
             'Accept': 'application/json',
             'Content-Type': 'application/json',
           },
-          signal: AbortSignal.timeout(10000) // 10 seconds timeout
+          signal: AbortSignal.timeout(10000)
         });
-
         if (response.ok) {
           const data: {
             data: TenderInvitationResponse[];
             total: number;
             page: number;
             limit: number;
-            supplierInfo?: {
-              supplierId: number;
-              activeRoundId: number;
-              thirdPartyId: number;
-            };
+            supplierInfo?: { supplierId: number; activeRoundId?: number; thirdPartyId: number };
           } = await response.json();
-
           return NextResponse.json({
             data: data.data,
             pagination: {
@@ -120,90 +113,16 @@ export async function GET(request: NextRequest) {
           });
         }
       } catch (error) {
-        console.warn('External API not available for tender invitations, using mock data:', error);
+        console.warn('External API not available for tender invitations:', error);
       }
     }
 
-    // Fallback to mock data if external API is unavailable
-    const mockInvitations: TenderInvitation[] = [
-      {
-        InvitationID: 1,
-        TenderId: 1,
-        SupplierId: 1,
-        InvitationDate: "2024-11-15T08:00:00.000Z",
-        ResponseStatus: "pending",
-        ResponseDate: undefined,
-        DeclineReason: undefined,
-        ConfirmationAttachment: undefined,
-        CreatedBy: "system",
-        CreatedOn: "2024-11-15T08:00:00.000Z",
-        ModifiedBy: undefined,
-        ModifiedOn: undefined,
-        DeletedBy: undefined,
-        DeletedOn: undefined,
-      },
-      {
-        InvitationID: 2,
-        TenderId: 2,
-        SupplierId: 1,
-        InvitationDate: "2024-11-10T10:00:00.000Z",
-        ResponseStatus: "accepted",
-        ResponseDate: "2024-11-12T14:30:00.000Z",
-        DeclineReason: undefined,
-        ConfirmationAttachment: undefined,
-        CreatedBy: "system",
-        CreatedOn: "2024-11-10T10:00:00.000Z",
-        ModifiedBy: "user",
-        ModifiedOn: "2024-11-12T14:30:00.000Z",
-        DeletedBy: undefined,
-        DeletedOn: undefined,
-      },
-    ];
-
-    // Filter mock data based on status if specified
-    let filteredInvitations = [...mockInvitations];
-    if (status !== 'all') {
-      filteredInvitations = filteredInvitations.filter(inv => inv.ResponseStatus === status);
-    }
-
-    // Create mock response data
-    const mockResponseData: TenderInvitationResponse[] = filteredInvitations.map(invitation => ({
-      invitation,
-        tender: {
-          id: invitation.TenderId,
-          tenderNo: invitation.TenderId === 1 ? "TENDER/2024/001" : "TENDER/2024/002",
-          title: invitation.TenderId === 1 ? "Supply and Installation of Office Equipment" : "Construction of Drainage System",
-          tenderType: invitation.TenderId === 1 ? "op" : "rs",
-          submissionDeadline: invitation.TenderId === 1 ? "2024-12-01T23:59:00.000Z" : "2024-11-30T17:00:00.000Z",
-          openingDate: invitation.TenderId === 1 ? "2024-12-02T10:00:00.000Z" : "2024-12-01T14:00:00.000Z",
-          status: "pb",
-          estimatedValue: invitation.TenderId === 1 ? "2500000" : "15000000",
-          currency: {
-            code: "KES",
-            symbol: "KSh"
-          }
-        }
-    }));
-
-    // Apply pagination
-    const startIndex = (page - 1) * limit;
-    const endIndex = startIndex + limit;
-    const paginatedData = mockResponseData.slice(startIndex, endIndex);
-
+    // No external API or failed: return empty set to avoid exposing wrong data
     return NextResponse.json({
-      data: paginatedData,
-      pagination: {
-        total: mockResponseData.length,
-        page,
-        limit,
-        pages: Math.ceil(mockResponseData.length / limit),
-      },
-      supplierInfo: {
-        supplierId: 1,
-        activeRoundId: 1,
-        thirdPartyId: thirdPartyId,
-      },
-      fallback: true, // Indicates this is mock data
+      data: [],
+      pagination: { total: 0, page, limit, pages: 0 },
+      supplierInfo: { supplierId: 0, activeRoundId: 0 as any, thirdPartyId },
+      fallback: true,
     });
 
   } catch (error) {

--- a/app/api/tenders/route.ts
+++ b/app/api/tenders/route.ts
@@ -288,6 +288,8 @@ export async function GET(request: NextRequest) {
     }
 
     const { searchParams } = request.nextUrl;
+    // Third-party user context (supplier portal)
+    const thirdPartyId = (session as any)?.user?.thirdPartyId as number | undefined;
     const search = searchParams.get('search');
     const status = searchParams.get('status');
     const tenderType = searchParams.get('tenderType');
@@ -303,6 +305,15 @@ export async function GET(request: NextRequest) {
         searchParams.forEach((value, key) => {
           apiUrl.searchParams.append(key, value);
         });
+
+        // Enforce invitation gating for restricted tenders in supplier portal context
+        if (thirdPartyId) {
+          apiUrl.searchParams.set('enforce_invites', 'true');
+          apiUrl.searchParams.set('third_party_id', String(thirdPartyId));
+        } else {
+          // Without supplier context, default to open tenders only
+          apiUrl.searchParams.set('status', 'open');
+        }
 
         const response = await fetch(apiUrl.toString(), {
           headers: {
@@ -344,6 +355,9 @@ export async function GET(request: NextRequest) {
     if (tenderType && tenderType !== 'all') {
       filteredTenders = filteredTenders.filter(tender => tender.tenderType === tenderType);
     }
+
+    // Enforce invitation gating in fallback: without real invitations, expose only open tenders
+    filteredTenders = filteredTenders.filter(tender => tender.tenderType === 'op');
 
     // Return paginated results
     const page = parseInt(searchParams.get('page') || '1');

--- a/components/tenders.tsx
+++ b/components/tenders.tsx
@@ -120,7 +120,8 @@ interface TenderWithInvitation extends Tender {
     invitation?: TenderInvitation;
 }
 
-const API_ROOT = `${getBaseUrl()}/api`;
+// Use Next.js API routes to ensure server adds supplier context and invitation gating
+const API_ROOT = `/api`;
 
 const containerVariants: Variants = {
     hidden: { opacity: 0 },


### PR DESCRIPTION
This pull request enhances the handling of tender invitations and tenders, particularly for supplier portal users, by enforcing invitation-based access to restricted tenders and improving data privacy. The main changes include removing mock data exposure, adding supplier context to API routing, and ensuring only open tenders are listed when supplier context is absent or unavailable.

**Tender Invitations API Improvements:**
* Removed fallback mock data from `app/api/tender-invitations/route.ts`, so if the external API is unavailable, the response will be an empty set instead of exposing sample/mock invitations. This prevents leaking test or incorrect data.
* Updated the `supplierInfo` object in the API response to default to zeroed values when the external API fails, maintaining consistent response structure without exposing real or mock supplier data.
* Changed the `supplierInfo` type to allow `activeRoundId` to be optional, improving compatibility with external API responses.

**Tender Listing API Enhancements:**
* Added supplier portal context (`thirdPartyId`) to the tenders API, enforcing invitation gating for restricted tenders when accessed by suppliers, and defaulting to open tenders for others. [[1]](diffhunk://#diff-d6bd62be661a2c4862bb79d08a7fbcdcb2610153dd41925d667afc0ce1213289R291-R292) [[2]](diffhunk://#diff-d6bd62be661a2c4862bb79d08a7fbcdcb2610153dd41925d667afc0ce1213289R309-R317)
* In fallback logic, further restricted the tenders list to only open tenders if real invitations are not available, ensuring proper access control in all scenarios.

**Frontend API Routing:**
* Updated the frontend to use Next.js API routes (`/api`) instead of a base URL, ensuring server-side logic applies supplier context and invitation gating consistently.