### PR TITLE
Fix the data display for suppliers

### DIFF
--- a/app/api/supplier-pos/[id]/route.ts
+++ b/app/api/supplier-pos/[id]/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getServerSession } from "next-auth"
+import { authOptions } from "../../auth/[...nextauth]/route"
+
+export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const session = await getServerSession(authOptions)
+    if (!session?.accessToken) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const base = process.env.NEXT_PUBLIC_EXTERNAL_API_URL
+    if (!base) return NextResponse.json({ error: "Backend not configured" }, { status: 500 })
+
+    const res = await fetch(`${base}/api/supplier-pos/${encodeURIComponent(params.id)}`, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${session.accessToken}`,
+      },
+      cache: "no-store",
+    })
+
+    const text = await res.text()
+    let json: any = null
+    try { json = text ? JSON.parse(text) : null } catch {}
+
+    if (!res.ok) return NextResponse.json(json ?? { error: "Upstream error" }, { status: res.status })
+    return NextResponse.json(json)
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || "Server error" }, { status: 500 })
+  }
+}
+
+
+

--- a/app/api/supplier-pos/route.ts
+++ b/app/api/supplier-pos/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getServerSession } from "next-auth"
+import { authOptions } from "../auth/[...nextauth]/route"
+
+export async function GET(_req: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions)
+    if (!session?.accessToken) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const base = process.env.NEXT_PUBLIC_EXTERNAL_API_URL
+    if (!base) return NextResponse.json({ error: "Backend not configured" }, { status: 500 })
+
+    const res = await fetch(`${base}/api/supplier-pos`, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${session.accessToken}`,
+      },
+      cache: "no-store",
+    })
+
+    const text = await res.text()
+    let json: any = null
+    try { json = text ? JSON.parse(text) : null } catch {}
+
+    if (!res.ok) return NextResponse.json(json ?? { error: "Upstream error" }, { status: res.status })
+
+    return NextResponse.json(json)
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || "Server error" }, { status: 500 })
+  }
+}
+
+
+

--- a/app/dashboard/po/[id]/page.tsx
+++ b/app/dashboard/po/[id]/page.tsx
@@ -1,0 +1,94 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useParams } from "next/navigation"
+
+type POLine = { id: number; item_id: number; description: string; qty: number; unit_price: number; line_total: number }
+type PO = { id: number; po_no: string; po_date: string; display_ref: string | null; total_incl: number; total_excl: number; total_tax: number }
+
+export default function SupplierPOViewPage() {
+  const params = useParams()
+  const poId = params?.id as string
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [order, setOrder] = useState<PO | null>(null)
+  const [lines, setLines] = useState<POLine[]>([])
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true)
+      setError(null)
+      try {
+        const res = await fetch(`/api/supplier-pos/${encodeURIComponent(poId)}`, { cache: "no-store" })
+        const json = await res.json()
+        if (!res.ok) throw new Error(json?.error || `Failed ${res.status}`)
+        setOrder(json?.data?.order || null)
+        setLines(json?.data?.lines || [])
+      } catch (e: any) {
+        setError(e?.message || "Failed to load PO")
+      } finally {
+        setLoading(false)
+      }
+    }
+    if (poId) load()
+  }, [poId])
+
+  const handlePrint = () => {
+    window.print()
+  }
+
+  return (
+    <div className="px-4 py-6 md:px-8">
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Purchase Order</h1>
+          <p className="text-muted-foreground">PO details and print view</p>
+        </div>
+        <button onClick={handlePrint} className="px-4 py-2 border rounded">Print</button>
+      </div>
+      {loading && <div>Loading...</div>}
+      {error && <div className="text-red-600">{error}</div>}
+      {!loading && !error && order && (
+        <div className="space-y-6 bg-white p-4 border rounded">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <div><span className="font-medium">PO No:</span> {order.po_no}</div>
+              <div><span className="font-medium">Date:</span> {order.po_date ? new Date(order.po_date).toLocaleDateString() : ''}</div>
+            </div>
+            <div>
+              <div><span className="font-medium">Source Ref:</span> {order.display_ref || '-'}</div>
+              <div><span className="font-medium">Total (Incl):</span> {Number(order.total_incl || 0).toLocaleString()}</div>
+            </div>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="min-w-full border">
+              <thead>
+                <tr className="bg-gray-50">
+                  <th className="p-2 text-left">Item</th>
+                  <th className="p-2 text-right">Qty</th>
+                  <th className="p-2 text-right">Unit Price</th>
+                  <th className="p-2 text-right">Line Total</th>
+                </tr>
+              </thead>
+              <tbody>
+                {lines.length === 0 ? (
+                  <tr><td className="p-4 text-center" colSpan={4}>No items</td></tr>
+                ) : lines.map((ln) => (
+                  <tr key={ln.id} className="border-t">
+                    <td className="p-2">{ln.description}</td>
+                    <td className="p-2 text-right">{Number(ln.qty).toLocaleString()}</td>
+                    <td className="p-2 text-right">{Number(ln.unit_price).toLocaleString()}</td>
+                    <td className="p-2 text-right">{Number(ln.line_total).toLocaleString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+
+

--- a/app/dashboard/po/page.tsx
+++ b/app/dashboard/po/page.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import Link from "next/link"
+
+type SupplierPO = {
+  id: number
+  po_no: string
+  po_date: string
+  source_ref: string | null
+  source_type: string | null
+  total_incl: number
+  total_tax: number
+  total_excl: number
+  display_ref: string | null
+}
+
+export default function SupplierPOListPage() {
+  const [data, setData] = useState<SupplierPO[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true)
+      setError(null)
+      try {
+        const res = await fetch("/api/supplier-pos", { cache: "no-store" })
+        const json = await res.json()
+        if (!res.ok) throw new Error(json?.error || `Failed ${res.status}`)
+        setData(json?.data || [])
+      } catch (e: any) {
+        setError(e?.message || "Failed to load POs")
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [])
+
+  return (
+    <div className="px-4 py-6 md:px-8">
+      <div className="mb-6 flex flex-col gap-2">
+        <h1 className="text-2xl font-semibold tracking-tight">Purchase Orders</h1>
+        <p className="text-muted-foreground">Your LPOs from RFQs or Tenders</p>
+      </div>
+      {loading && <div>Loading...</div>}
+      {error && <div className="text-red-600">{error}</div>}
+      {!loading && !error && (
+        <div className="overflow-x-auto">
+          <table className="min-w-full border">
+            <thead>
+              <tr className="bg-gray-50">
+                <th className="p-2 text-left">PO No</th>
+                <th className="p-2 text-left">Date</th>
+                <th className="p-2 text-left">Source</th>
+                <th className="p-2 text-right">Total (Incl)</th>
+                <th className="p-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.length === 0 ? (
+                <tr><td className="p-4 text-center" colSpan={5}>No POs found</td></tr>
+              ) : data.map((row) => (
+                <tr key={row.id} className="border-t">
+                  <td className="p-2">{row.po_no}</td>
+                  <td className="p-2">{row.po_date ? new Date(row.po_date).toLocaleDateString() : ''}</td>
+                  <td className="p-2">{row.display_ref || row.source_ref || '-'}</td>
+                  <td className="p-2 text-right">{Number(row.total_incl || 0).toLocaleString()}</td>
+                  <td className="p-2 text-center">
+                    <Link href={`/dashboard/po/${row.id}`} className="underline">View</Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+
+


### PR DESCRIPTION
This pull request introduces a new supplier purchase order (PO) dashboard feature, including backend API routes for fetching PO data and frontend pages for listing and viewing individual POs. The changes provide secure, authenticated access to PO data and user-friendly interfaces for viewing and printing PO details.

**Backend API additions:**

* Added `GET` endpoint in `app/api/supplier-pos/route.ts` to fetch a list of supplier POs, with authentication and error handling.
* Added `GET` endpoint in `app/api/supplier-pos/[id]/route.ts` to fetch details of a specific PO, including authentication and upstream error propagation. ([app/api/supplier-pos/[id]/route.tsR1-R35](diffhunk://#diff-e37a82d38a65441302cb4190de4a284ed5fdca8f85977fc0ccb6b959e02f2512R1-R35))

**Frontend dashboard pages:**

* Implemented `app/dashboard/po/page.tsx` to display a list of supplier POs, with loading/error states and links to view individual POs.
* Implemented `app/dashboard/po/[id]/page.tsx` to show detailed PO information and line items, including a print view and error/loading handling. ([app/dashboard/po/[id]/page.tsxR1-R94](diffhunk://#diff-e83510392c3c9b3f04016a7c47b3f68d00aba33bad34111fe6e42cbb890441f9R1-R94))