### PR TITLE
feat: Add `verification_base_url` to registration API data.

### DIFF
--- a/hooks/use-register.ts
+++ b/hooks/use-register.ts
@@ -143,7 +143,10 @@ export const useRegisterForm = () => {
                 return
             }
 
-            const apiData = transformRegisterFormDataForApi(data)
+            const apiData = {
+                ...transformRegisterFormDataForApi(data),
+                verification_base_url: typeof window !== 'undefined' ? window.location.origin : ''
+            }
 
             try {
                 const response = await fetch(`${API_BASE_URL}/api/third-party-auth/register`, {


### PR DESCRIPTION
This pull request makes a small but important update to the `useRegisterForm` hook to include a `verification_base_url` when sending registration data to the API. This ensures that the backend receives the correct base URL for verification links.

* Added `verification_base_url` (derived from `window.location.origin` if available) to the registration API payload in `use-register.ts` (`useRegisterForm`).