### PR TITLE
chore: Re-enable build linting and configure ESLint to ignore errors …

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,9 @@ const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
   reactStrictMode: true,
   compiler: {
     removeConsole: process.env.NODE_ENV === "production" ? { exclude: ["error"] } : false,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build --no-lint",
+    "build": "next build",
     "start": "next start",
     "lint": "next lint"
   },


### PR DESCRIPTION
This pull request updates the build and linting configuration for the Next.js project to streamline the build process and ensure consistent linting behavior. The main changes involve how ESLint is handled during builds and the related build script configuration.

**Build and Linting Configuration:**

* Updated the build script in `package.json` to run `next build` without the `--no-lint` flag, relying on Next.js configuration for linting behavior.
* Added an `eslint` configuration block in `next.config.ts` to set `ignoreDuringBuilds: true`, which disables ESLint checks during the production build process.…during builds.